### PR TITLE
Support ContentLength Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
 Stores bytes on disks.
 
 ```
-Client -> [8B TicketID | 8B Checksum | 1458B Data] -> Server
+Client -> [8B ContentLength | 1450B Data] -> Router
+
+Router -> [8B TicketID | 8B Checksum | 1450B Data] -> PutterNode
 
 Server -> WriteDataToDisk() -> [8B TicketID | 1B Status] -> Client
 ```
 
 ## Overview
 
-Simple Object Store consists of a DataPutter, DataReceiver, and Datastore.
+Simple Object Store consists of a DataPutter, Router, and Datastore.
 
-* A File is sent to **DataReceiver** who turns it into 1458-byte chunks.
+* A File is sent to **Router** who turns it into 1450-byte chunks.
 * Each chunk is sent to a **DataPutter** to store
 * When all chunks are stored, the file has been "Received"
 
@@ -25,7 +27,7 @@ Router: 5001
 
 # RunsOn: Router
 # Handles responses to ticket write requests
-Router: 5002
+TicketResponseServer: 5002
 
 # RunsOn: Router
 # Handles requests to retrieve bytes of an object
@@ -42,7 +44,7 @@ DataPutter receives requests of the structure:
 
 ```
 ---------------- ---------------- ----~----
-| 8B            | 8B             | 1458B   |
+| 8B            | 8B             | 1450B   |
 | TicketID      |Checksum        |Data     |
 ---------------- ---------------- ---------
 ```
@@ -63,7 +65,7 @@ An opaque collection of bytes aligned to the default `1500 byte` MTU - `40 Bytes
 
 ### Data Putter : Placing Bytes
 
-Bytes are written to the path corresponding to ordered length-2 strings from the `TicketID`. For example, the TicketID `AABBCCDD` will become the filepath `/AA/BB/CC/DD/obj`.
+Bytes are written to the path corresponding to ordered length-2 strings from the `TicketID`. For example, the TicketID `AABBCCDD` will become the filepath `/A/A/B/B/C/C/D/D/obj`.
 
 # Running
 

--- a/dataputter/datastore.go
+++ b/dataputter/datastore.go
@@ -156,25 +156,22 @@ type CounterEvent struct {
 // Watches a key for Version updates
 func WatchCounter(keyPath string, observers chan CounterEvent) error {
 	fmt.Printf("WatchCounter starting for %s\n", keyPath)
-	var lastValue int64
+
 	if v, err := getCounter(keyPath); err != nil {
 		fmt.Printf("Unable to get counter %s\n", keyPath)
 		return err
 	} else {
-		lastValue = v
+		observers <- CounterEvent{keyPath, v}
 	}
 
 	// 200 Hz
 	for range time.Tick(time.Millisecond * 5) {
 		v, err := getCounter(keyPath)
 		if err == nil {
-			if v != lastValue {
-				observers <- CounterEvent{
-					keyPath,
-					v,
-				}
+			observers <- CounterEvent{
+				keyPath,
+				v,
 			}
-			lastValue = v
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,20 +65,23 @@ func main() {
 						response.Status,
 						err,
 					)
-					continue
+				} else {
+					fmt.Printf("\tCommitted Ticket %s status %s to datatore\n",
+						string(response.TicketID),
+						dataputter.TicketStatus[response.Status],
+					)
 				}
 			}
 		}(putterResponses)
 
-		// Listen for inbound files [Router]
-		go dataputter.RouterServer(5001, intake)
 		// Listen for Putter write responses (block) [Router]
 		go dataputter.PutterResponseServer(5002, putterResponses)
-
 		// Listen for Object read requests [Router]
 		go dataputter.ObjectRequestServer(5004)
 		// Listen for Ticket read requests [PutterNode]
-		dataputter.TicketRequestServer(5005)
+		go dataputter.TicketRequestServer(5005)
+		// Listen for inbound files [Router]
+		dataputter.RouterServer(5001, intake)
 
 	// Byte Putter server
 	case "putter":


### PR DESCRIPTION
In order to both receive and write a file to the object store, the Router needs to know how much content there is since it will not encounter an `io.EOF` when the remote socket is trying to read bytes from it.

An 8 byte big-endian prefix provides the length of the content to follow. Since the object store limit is ~24 GB, the ~16 GB content limit per upload should be fine.

Updated documentation to reflect the change in the File Upload Packet Format from

```
[ 1458 Byte Data ]
```

to

```
[ 8 B ContentLength | 1450 byte Data ]
```