### PR TITLE
Delete Object with GRPC

### DIFF
--- a/dataputter/server.go
+++ b/dataputter/server.go
@@ -22,37 +22,6 @@ func WriteTicketHandler(work chan WriteTicket) {
 	}
 }
 
-// DeleteTicketHandler Receives Delete Request tickets and sends Delete
-// Ticket confirmations. It runs on a DataPutter Node so that it has
-// access to bytes
-// * Delete bytes (Ticket bytes) this Node
-// * Delete Ticket references
-// * Delete Object reference
-// * Has no datastore access
-func DeleteTicketHandler(requests chan DeleteTicketRequest, confirmations chan DeleteTicketConfirmation) {
-	// for req := range requests {
-	// fmt.Printf("DeleteTicketHandler deleting %s/%s on node %s\n",
-	// 	req.ObjectID,
-	// 	req.TicketID,
-	// 	req.NodeID,
-	// )
-	// filename := ObjectPathString(req.TicketID) + "/obj"
-	// err := deleteBytes(filename)
-	// if err != nil {
-	// 	fmt.Printf("DeleteTicketHandler failed to delete %s: %v\n", filename, err)
-	// }
-	// confirmation := DeleteTicketConfirmation{
-	// 	req.TicketID,
-	// 	req.ObjectID,
-	// 	req.NodeID,
-	// 	req.TicketIndex,
-	// 	err == nil,
-	// }
-
-	// confirmations <- confirmation
-	// }
-}
-
 // [8B TicketID][8B Checksum][nB Data]
 // Data should be 1458 Bytes for best results
 func parseTicketRequest(b []byte) WriteTicket {


### PR DESCRIPTION
Utilize GRPC for requests to dataPutters (WriteNodes) to delete a ticket and object. No change to the external API