### PR TITLE
Config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Simple Object Store consists of a WriteNode, Router, and Datastore.
 * Each chunk is sent to a **WriteNode** to store
 * When all chunks are stored, the file has been "Received"
 
+## Configuration
+
+YAML can be used to provide a topology configuration to a Router.
+
+```
+# router.yaml
+
+port: 5001
+bind: 0.0.0.0
+
+nodes:
+  - host: hostA
+    port: 5002
+  - host: hostB
+    port: 5002
+```
+
 ### Roles and Ports
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	google.golang.org/grpc v1.33.2
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.1 // indirect
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v2 v2.4.0
 	honnef.co/go/tools v0.0.1-2020.1.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=


### PR DESCRIPTION
Supports the creation of a YAML configuration file. If the configuration file is not found at the place pointed to by `DATAPUTTER_CONFIG_ROOT` or at `./config.yaml` then a default configuration will be used.

The default configuration is only valid for the standAlone mode.